### PR TITLE
Add support for incremental builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ To keep it as even as possible, the static site generators builds are designed w
 - Only use plugins required to read and write markdown files.
 - Builds are run from scratch after clearing caches.
 
+In addition, the test runner will add a single markdown file and re-run without cleaning, using an optional incremental build command. This provides an opportunity for SSG's with slower build processes to show approaches to scaling.
+
 ## Running Locally
 
 If you'd like to try out this project locally, first clone the project:
@@ -80,7 +82,10 @@ The configuration for a SSG looks like this:
     clean: "rm -rf _site && rm -rf .jekyll-cache",
     // Command to run the build process for the SSG. This should leave HTML
     // files in the build directory after completion.
-    build: "bundle exec jekyll build"
+    build: "bundle exec jekyll build",
+    // Command to run the build process for the SSG while accounting for a
+    // single added markdown file.
+    build: "bundle exec jekyll build --incremental"
   }
 }
 ```

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -16,20 +16,6 @@ module.exports = class Builder {
   }
 
   /**
-   * Run build command.
-   */
-  build() {
-    return this.runCmd(this.config.commands.build, this.config.paths.root)
-  }
-
-  /**
-   * Run clean command.
-   */
-  clean() {
-    return this.runCmd(this.config.commands.clean, this.config.paths.root)
-  }
-
-  /**
    * Counts the number of files in the build directory.
    */
   countBuildFiles(ext) {
@@ -49,7 +35,8 @@ module.exports = class Builder {
   async runCmd(cmd, dir = ".") {
     return new Promise((resolve, reject) => {
       const startTime = new Date()
-      exec(cmd, { cwd: dir, maxBuffer: 1024 * 1000 }, (err, stdout, stderr) => {
+      const cmdOptions = { cwd: this.config.paths.root, maxBuffer: 1024 * 1000 }
+      exec(this.config.commands[cmd], cmdOptions, (err, stdout, stderr) => {
         const endTime = new Date()
         const elapsedTime = (endTime - startTime) / 1000.0
         return err ? reject(err, elapsedTime) : resolve(elapsedTime)

--- a/lib/builder.spec.js
+++ b/lib/builder.spec.js
@@ -50,12 +50,12 @@ describe("build()", () => {
   it("runs the build command", async () => {
     expect.assertions(2)
     expect(fs.existsSync(mockConfig.paths.build)).toEqual(false)
-    await builder.build()
+    await builder.runCmd("build")
     expect(fs.existsSync(mockConfig.paths.build)).toEqual(true)
   })
   it("returns the number of seconds it took to run", async () => {
     expect.assertions(2)
-    const duration = await builder.build()
+    const duration = await builder.runCmd("build")
     expect(typeof duration).toEqual("number")
     expect(duration < 1).toEqual(true)
   })
@@ -67,9 +67,9 @@ describe("clean()", () => {
   it("runs the clean command", async () => {
     expect.assertions(3)
     expect(fs.existsSync(mockConfig.paths.build)).toEqual(false)
-    await builder.build()
+    await builder.runCmd("build")
     expect(fs.existsSync(mockConfig.paths.build)).toEqual(true)
-    await builder.clean()
+    await builder.runCmd("clean")
     expect(fs.existsSync(mockConfig.paths.build)).toEqual(false)
   })
 })
@@ -81,17 +81,17 @@ describe("countBuildFiles()", () => {
     expect(builder.countBuildFiles()).toEqual(0)
   })
   it("counts all files in the build directory", async () => {
-    await builder.build()
+    await builder.runCmd("build")
     expect(builder.countBuildFiles()).toEqual(2)
   })
   it("ignores directories in its count", async () => {
-    await builder.build()
+    await builder.runCmd("build")
     fs.mkdirSync(path.resolve(mockConfig.paths.build, "subdir"))
     expect(glob.sync(`${mockConfig.paths.build}/**/*`).length).toEqual(3)
     expect(builder.countBuildFiles()).toEqual(2)
   })
   it("can filter by extension", async () => {
-    await builder.build()
+    await builder.runCmd("build")
     expect(builder.countBuildFiles(".html")).toEqual(1)
     expect(builder.countBuildFiles(".xml")).toEqual(1)
     expect(builder.countBuildFiles(".js")).toEqual(0)

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -51,13 +51,13 @@ module.exports = class Logger {
    * @param {string} result.name The name of the test. Required.
    * @param {number} result.count The number of files tested. Required.
    */
-  storeResult(result = {}) {
+  storeResult(result = {}, type = "count") {
     // Require name and count.
     if (!lodash.get(result, "name") || !lodash.get(result, "count")) {
       throw "Name and count required."
     }
     // The key within the name.
-    const storeKey = `${result.name}.count-${result.count}`
+    const storeKey = `${result.name}.${type}-${result.count}`
     // The number of results to store for this particular group.
     const keepCount = this.config.maxHistory - 1
     // Retrieve the most recent results for this group, leaving room for the new

--- a/lib/logger.spec.js
+++ b/lib/logger.spec.js
@@ -88,10 +88,18 @@ describe("generateTimestamp()", () => {
 describe("storeResult()", () => {
   beforeEach(() => (logger = new Logger({ file: mockConfig.file })))
 
-  it("nests them in a name and count key", () => {
+  it("nests them in a name and 'count' key by default", () => {
     expect(logger.results).toEqual({})
     logger.storeResult(mockResult)
     const storedResult = logger.results.hugo["count-1"][0]
+    expect(storedResult.name).toEqual(mockResult.name)
+    expect(storedResult.count).toEqual(mockResult.count)
+    expect(storedResult.timestamp).not.toBeUndefined()
+  })
+  it("allows the count prefix to be altered", () => {
+    expect(logger.results).toEqual({})
+    logger.storeResult(mockResult, "incremental")
+    const storedResult = logger.results.hugo["incremental-1"][0]
     expect(storedResult.name).toEqual(mockResult.name)
     expect(storedResult.count).toEqual(mockResult.count)
     expect(storedResult.timestamp).not.toBeUndefined()

--- a/lib/run.js
+++ b/lib/run.js
@@ -1,6 +1,10 @@
 const ProgressBar = require("progress")
 
-const { cleanDir: removeTestFiles, generateFiles: generateTestFiles } = require("./generator")
+const {
+  cleanDir: removeTestFiles,
+  generateFiles: generateTestFiles,
+  generateFile: generateSingleTestFile
+} = require("./generator")
 const Logger = require("./logger")
 const Builder = require("./builder")
 
@@ -30,21 +34,38 @@ const run = async () => {
       message: `Building ${test.name} with ${test.count} files ...`
     })
     // Clean the build directory.
-    await builder.clean()
+    await builder.runCmd("clean")
     // Generate markdown files.
     await generateTestFiles(test.paths.content, test.count)
     // Run the build and store the time it took to run.
-    const duration = await builder.build()
+    const duration = await builder.runCmd("build")
     // Store the results
-    logger.storeResult({
+    const results = {
       name: test.name,
       count: test.count,
       duration: duration,
       buildFileCount: builder.countBuildFiles(),
       buildHtmlFileCount: builder.countBuildFiles(".html")
-    })
+    }
+    logger.storeResult(results)
+    // Run incremental build ...
+    //  Add a single file
+    await generateSingleTestFile(test.paths.content)
+    // Run the build and store the time it took to run.
+    const incrementalDuration = await builder.runCmd("incremental_build")
+    // Store the results
+    logger.storeResult(
+      {
+        ...results,
+        duration: incrementalDuration,
+        buildFileCount: builder.countBuildFiles(),
+        buildHtmlFileCount: builder.countBuildFiles(".html")
+      },
+      "incremental"
+    )
+
     // Clean up the build directory.
-    await builder.clean()
+    await builder.runCmd("clean")
     // Remove markdown files.
     removeTestFiles(test.paths.content)
   }

--- a/src/assets/js/main.js
+++ b/src/assets/js/main.js
@@ -11,8 +11,25 @@ const resultsCtx = document.getElementById("results-chart").getContext("2d")
 const resultsChart = new Chart(resultsCtx, {
   type: "line",
   data: {
-    labels: results.labels,
-    datasets: results.data.map(result => ({
+    labels: results.default.labels,
+    datasets: results.default.data.map(result => ({
+      ...result,
+      fill: false,
+      backgroundColor: result.color,
+      borderColor: result.color
+    }))
+  }
+})
+
+// ---------------------------------------- | Incremental Chart
+
+const incrementalCtx = document.getElementById("incremental-chart").getContext("2d")
+
+const incrementalChart = new Chart(incrementalCtx, {
+  type: "line",
+  data: {
+    labels: results.incremental.labels,
+    datasets: results.incremental.data.map(result => ({
       ...result,
       fill: false,
       backgroundColor: result.color,
@@ -33,12 +50,12 @@ const resultsSingleFileChart = new Chart(resultsSingleFile, {
     }
   },
   data: {
-    labels: results.data.map(({ label }) => label),
+    labels: results.default.data.map(({ label }) => label),
     datasets: [
       {
         label: "Build Time (s)",
-        data: results.data.map(result => result.data[0]),
-        backgroundColor: results.data.map(({ color }) => color)
+        data: results.default.data.map(result => result.data[0]),
+        backgroundColor: results.default.data.map(({ color }) => color)
       }
     ]
   }

--- a/src/index.njk
+++ b/src/index.njk
@@ -13,12 +13,12 @@ layout: layout
     <table class="table-auto mx-auto">
       <thead>
         <th class="border px-4 py-2 bg-gray-200">Name</th>
-        {% for label in results.labels %}
+        {% for label in results.default.labels %}
           <th class="border px-4 py-2 bg-gray-200">{{ label }}</th>
         {% endfor %}
       </thead>
       <tbody>
-        {% for result in results.data %}
+        {% for result in results.default.data %}
           <tr>
             <td class="border px-4 py-2">{{ result.label }}</td>
             {% for item in result.data %}
@@ -33,6 +33,33 @@ layout: layout
   <div class="max-w-2xl mx-auto mb-12">
     <h3 class="text-lg font-bold mb-2 text-center">Build Scaling Performance</h2>
     <canvas id="results-chart" width="400" height="400"></canvas>
+  </div>
+
+  <div class="mb-12">
+    <h3 class="text-lg font-bold mb-2 text-center">Average Incremental Results</h2>
+    <table class="table-auto mx-auto">
+      <thead>
+        <th class="border px-4 py-2 bg-gray-200">Name</th>
+        {% for label in results.incremental.labels %}
+          <th class="border px-4 py-2 bg-gray-200">{{ label }}</th>
+        {% endfor %}
+      </thead>
+      <tbody>
+        {% for result in results.incremental.data %}
+          <tr>
+            <td class="border px-4 py-2">{{ result.label }}</td>
+            {% for item in result.data %}
+              <td class="border px-4 py-2">{{ item }}</td>
+            {% endfor %}
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+
+  <div class="max-w-2xl mx-auto mb-12">
+    <h3 class="text-lg font-bold mb-2 text-center">Incremental Build Scaling Performance</h2>
+    <canvas id="incremental-chart" width="400" height="400"></canvas>
   </div>
 
   <div class="max-w-2xl mx-auto mb-12">

--- a/src/results.json
+++ b/src/results.json
@@ -498,14 +498,6 @@
       {
         "name": "jekyll",
         "count": 1000,
-        "duration": 1.88,
-        "buildFileCount": 1000,
-        "buildHtmlFileCount": 1000,
-        "timestamp": 1598179698651
-      },
-      {
-        "name": "jekyll",
-        "count": 1000,
         "duration": 1.941,
         "buildFileCount": 1000,
         "buildHtmlFileCount": 1000,
@@ -574,6 +566,14 @@
         "buildFileCount": 1000,
         "buildHtmlFileCount": 1000,
         "timestamp": 1598315076547
+      },
+      {
+        "name": "jekyll",
+        "count": 1000,
+        "duration": 1.837,
+        "buildFileCount": 1000,
+        "buildHtmlFileCount": 1000,
+        "timestamp": 1598521552623
       }
     ],
     "count-5000": [
@@ -656,6 +656,16 @@
         "buildFileCount": 5000,
         "buildHtmlFileCount": 5000,
         "timestamp": 1598315085596
+      }
+    ],
+    "incremental-1000": [
+      {
+        "name": "jekyll",
+        "count": 1000,
+        "duration": 1.981,
+        "buildFileCount": 1001,
+        "buildHtmlFileCount": 1001,
+        "timestamp": 1598521554670
       }
     ]
   },

--- a/test.config.js
+++ b/test.config.js
@@ -1,8 +1,8 @@
 const path = require("path")
 
 module.exports = {
-  // fileCount: [1, 100, 1000, 5000],
-  fileCount: [10000, 20000],
+  fileCount: [1, 100, 1000, 5000],
+  // fileCount: [10000, 20000],
   log: {
     file: path.resolve(__dirname, `src/results.json`),
     maxHistory: 10
@@ -18,7 +18,8 @@ module.exports = {
       },
       commands: {
         clean: "rm -rf public",
-        build: "hugo -D"
+        build: "hugo -D",
+        incremental_build: "hugo -D"
       }
     },
     {
@@ -31,7 +32,8 @@ module.exports = {
       },
       commands: {
         clean: "rm -rf _site && rm -rf .jekyll-cache",
-        build: "bundle exec jekyll build"
+        build: "bundle exec jekyll build",
+        incremental_build: "bundle exec jekyll build --incremental"
       }
     },
     {
@@ -44,7 +46,8 @@ module.exports = {
       },
       commands: {
         clean: "yarn clean",
-        build: "yarn build"
+        build: "yarn build",
+        incremental_build: "yarn build"
       }
     },
     {
@@ -57,7 +60,8 @@ module.exports = {
       },
       commands: {
         clean: "yarn clean",
-        build: "yarn build"
+        build: "yarn build",
+        incremental_build: "yarn build"
       }
     },
     {
@@ -70,7 +74,8 @@ module.exports = {
       },
       commands: {
         clean: "yarn clean",
-        build: "yarn build && yarn export"
+        build: "yarn build && yarn export",
+        incremental_build: "yarn build && yarn export"
       }
     },
     {
@@ -83,7 +88,8 @@ module.exports = {
       },
       commands: {
         clean: "yarn clean",
-        build: "yarn generate"
+        build: "yarn generate",
+        incremental_build: "yarn generate"
       }
     }
   ]


### PR DESCRIPTION
This provides a way to add incremental builds to each test. It requires the command be in there by default, but it could be the same as the build command.

Currently, I've only adjusted Jekyll's build command (which didn't make much difference on the first run).