### PR TITLE
[Fixes #5] Update Jekyll

### DIFF
--- a/lib/import.js
+++ b/lib/import.js
@@ -17,7 +17,10 @@ const db = new Database({
 
 const GET_RESULTS_QUERY = gql`
   query GetResultsQuery {
-    results(where: { count: { _neq: 0 } }) {
+    results(
+      order_by: [{ generator: { title: asc } }, { count: asc }, { created_at: asc }]
+      where: { count: { _neq: 0 } }
+    ) {
       build_file_count
       build_html_file_count
       count

--- a/ssg/jekyll/Gemfile
+++ b/ssg/jekyll/Gemfile
@@ -7,7 +7,7 @@ source "https://rubygems.org"
 #
 # This will help ensure the proper Jekyll version is running.
 # Happy Jekylling!
-gem "jekyll", "~> 4.1.1"
+gem "jekyll", github: "jekyll/jekyll"
 # This is the default theme for new Jekyll sites. You may change this to anything you like.
 # gem "minima", "~> 2.5"
 # If you want to use GitHub Pages, remove the "gem "jekyll"" above and

--- a/ssg/jekyll/Gemfile.lock
+++ b/ssg/jekyll/Gemfile.lock
@@ -1,11 +1,31 @@
+GIT
+  remote: git://github.com/jekyll/jekyll.git
+  revision: bcbc451a26405678c9d2d2a077e71cc92069dfc6
+  specs:
+    jekyll (4.1.1)
+      addressable (~> 2.4)
+      colorator (~> 1.0)
+      em-websocket (~> 0.5)
+      i18n (~> 1.0)
+      jekyll-sass-converter (~> 2.0)
+      jekyll-watch (~> 2.0)
+      kramdown (~> 2.3)
+      kramdown-parser-gfm (~> 1.0)
+      liquid (~> 4.0)
+      mercenary (~> 0.4.0)
+      pathutil (~> 0.9)
+      rouge (~> 3.0)
+      safe_yaml (~> 1.0)
+      terminal-table (~> 2.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     colorator (1.1.0)
-    concurrent-ruby (1.1.6)
-    em-websocket (0.5.1)
+    concurrent-ruby (1.1.7)
+    em-websocket (0.5.2)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
     eventmachine (1.2.7)
@@ -14,21 +34,6 @@ GEM
     http_parser.rb (0.6.0)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
-    jekyll (4.1.1)
-      addressable (~> 2.4)
-      colorator (~> 1.0)
-      em-websocket (~> 0.5)
-      i18n (~> 1.0)
-      jekyll-sass-converter (~> 2.0)
-      jekyll-watch (~> 2.0)
-      kramdown (~> 2.1)
-      kramdown-parser-gfm (~> 1.0)
-      liquid (~> 4.0)
-      mercenary (~> 0.4.0)
-      pathutil (~> 0.9)
-      rouge (~> 3.0)
-      safe_yaml (~> 1.0)
-      terminal-table (~> 1.8)
     jekyll-sass-converter (2.1.0)
       sassc (> 2.0.1, < 3.0)
     jekyll-watch (2.2.1)
@@ -44,16 +49,16 @@ GEM
     mercenary (0.4.0)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
-    public_suffix (4.0.5)
+    public_suffix (4.0.6)
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     rexml (3.2.4)
-    rouge (3.21.0)
+    rouge (3.24.0)
     safe_yaml (1.0.5)
     sassc (2.4.0)
       ffi (~> 1.9)
-    terminal-table (1.8.0)
+    terminal-table (2.0.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
     unicode-display_width (1.7.0)
 
@@ -61,7 +66,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  jekyll (~> 4.1.1)
+  jekyll!
   tzinfo (~> 1.2)
   tzinfo-data
   wdm (~> 0.1.1)

--- a/test.config.js
+++ b/test.config.js
@@ -56,9 +56,9 @@ module.exports = {
       }
     },
     {
-      name: "jekyll_upgrade",
+      name: "jekyll",
       version: "4.1.1 (master)",
-      color: "#40ff50",
+      color: "#fc0",
       paths: {
         build: path.join(__dirname, "ssg/jekyll/_site"),
         content: path.join(__dirname, "ssg/jekyll/_pages"),

--- a/test.config.js
+++ b/test.config.js
@@ -56,9 +56,9 @@ module.exports = {
       }
     },
     {
-      name: "jekyll",
-      version: "4.1.1",
-      color: "#fc0",
+      name: "jekyll_upgrade",
+      version: "4.1.1 (master)",
+      color: "#40ff50",
       paths: {
         build: path.join(__dirname, "ssg/jekyll/_site"),
         content: path.join(__dirname, "ssg/jekyll/_pages"),


### PR DESCRIPTION
This updates Jekyll against the primary GitHub branch. This appears to increase the performance by 10% at 64k, and a bit less dramatically at lower values. But it doesn't adjust where Jekyll falls in relation to the competition.

Here are relative results after one run:

<img width="701" alt="Screen Shot 2020-11-06 at 11 48 30 AM" src="https://user-images.githubusercontent.com/5245089/98400649-6632f000-2032-11eb-8f3a-28f4daab1316.png">

<img width="697" alt="Screen Shot 2020-11-06 at 11 48 38 AM" src="https://user-images.githubusercontent.com/5245089/98400651-66cb8680-2032-11eb-8159-15d8ddb59143.png">
