### PR TITLE
Fix Microsite large runs

### DIFF
--- a/.github/workflows/run-base-dataset.yml
+++ b/.github/workflows/run-base-dataset.yml
@@ -60,6 +60,20 @@ jobs:
         env:
           HASURA_SECRET: ${{ secrets.HASURA_SECRET }}
           HASURA_URL: ${{ secrets.HASURA_URL }}
+  run-microsite-base:
+    name: "[Dataset: Base] Microsite"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Dependencies
+        run: npm install
+      - name: Install SSG Dependencies
+        run: cd ssg/microsite && npm install
+      - name: Run Build
+        run: node lib/run.js base --generators microsite
+        env:
+          HASURA_SECRET: ${{ secrets.HASURA_SECRET }}
+          HASURA_URL: ${{ secrets.HASURA_URL }}
   run-next-base:
     name: "[Dataset: Base] Next"
     runs-on: ubuntu-latest

--- a/.github/workflows/run-dev-dataset.yml
+++ b/.github/workflows/run-dev-dataset.yml
@@ -60,6 +60,20 @@ jobs:
         env:
           HASURA_SECRET: ${{ secrets.HASURA_SECRET }}
           HASURA_URL: ${{ secrets.HASURA_URL }}
+  run-microsite-dev:
+    name: "[Dataset: Dev] Microsite"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Dependencies
+        run: npm install
+      - name: Install SSG Dependencies
+        run: cd ssg/microsite && npm install
+      - name: Run Build
+        run: node lib/run.js dev --generators microsite
+        env:
+          HASURA_SECRET: ${{ secrets.HASURA_SECRET }}
+          HASURA_URL: ${{ secrets.HASURA_URL }}
   run-next-dev:
     name: "[Dataset: Dev] Next"
     runs-on: ubuntu-latest

--- a/.github/workflows/run-large-dataset.yml
+++ b/.github/workflows/run-large-dataset.yml
@@ -62,6 +62,20 @@ jobs:
         env:
           HASURA_SECRET: ${{ secrets.HASURA_SECRET }}
           HASURA_URL: ${{ secrets.HASURA_URL }}
+  run-microsite-large:
+    name: "[Dataset: Large] Microsite"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Dependencies
+        run: npm install
+      - name: Install SSG Dependencies
+        run: cd ssg/microsite && npm install
+      - name: Run Build
+        run: node lib/run.js large --generators microsite
+        env:
+          HASURA_SECRET: ${{ secrets.HASURA_SECRET }}
+          HASURA_URL: ${{ secrets.HASURA_URL }}
   run-next-large:
     name: "[Dataset: Large] Next"
     runs-on: ubuntu-latest

--- a/.github/workflows/run-small-dataset.yml
+++ b/.github/workflows/run-small-dataset.yml
@@ -60,6 +60,20 @@ jobs:
         env:
           HASURA_SECRET: ${{ secrets.HASURA_SECRET }}
           HASURA_URL: ${{ secrets.HASURA_URL }}
+  run-microsite-small:
+    name: "[Dataset: Small] Microsite"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Dependencies
+        run: npm install
+      - name: Install SSG Dependencies
+        run: cd ssg/microsite && npm install
+      - name: Run Build
+        run: node lib/run.js small --generators microsite
+        env:
+          HASURA_SECRET: ${{ secrets.HASURA_SECRET }}
+          HASURA_URL: ${{ secrets.HASURA_URL }}
   run-next-small:
     name: "[Dataset: Small] Next"
     runs-on: ubuntu-latest


### PR DESCRIPTION
@natemoo-re I merged this in and everything was going well ... until we got to the large site builds. Notice [on the most recent](https://github.com/seancdavis/ssg-build-performance-tests/runs/2220208191?check_suite_focus=true) that it ran out of memory.

I ripped out previous results and have removed Microsite from the list since it can't complete the full test. This PR configures the workflows for GitHub Actions, which are the official runs.

To get Microsite back in, we'll first merge these changes. In order to do so, please first make sure that the following command finishes locally for you:

    $ node lib/run.js large --generators microsite --dryrun

Once it does, we'll run the large workflow against this branch. You're also welcome to adjust the server or commands being run. Notice [we had to do a thing for Gatsby](https://github.com/seancdavis/ssg-build-performance-tests/blob/main/.github/workflows/run-large-dataset.yml#L25-L26) on large builds.