### PR TITLE
Update docs for `ssgConfig.paths.content`

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,8 +98,8 @@ The configuration for a SSG looks like this:
     // Directory in which the SSG's built files will reside after running a
     // build.
     build: path.join(__dirname, "ssg/jekyll/_site"),
-    // Directory in which to generate markdown files. This will be cleaned after
-    // each build.
+    // Directory in which to generate markdown files. All markdown files in
+    // this directory will be cleaned after each build.
     content: path.join(__dirname, "ssg/jekyll/_pages"),
     // Project root directory.
     root: path.join(__dirname, "ssg/jekyll")


### PR DESCRIPTION
Not totally happy with my wording, but I figure this is an important clarification! I've been dancing around, trying to ensure that `rm -rf content/**` wouldn't make the generator fail, but it appears I was wrong to worry about that:

https://github.com/seancdavis/ssg-build-performance-tests/blob/1fbcec686795a2f6f8476bc4c955af676675be94/lib/generator.js#L17